### PR TITLE
Add Windows OS check and document requirement

### DIFF
--- a/BIOSData.ps1
+++ b/BIOSData.ps1
@@ -28,6 +28,11 @@
   
 #>
 
+# Ensure script runs only on Windows
+if (-not ($PSVersionTable.OS -like '*Windows*' -or $IsWindows)) {
+    throw "LenovoBIOSUpdater requires Windows to run. WinAIA and BIOS interactions are not supported on non-Windows platforms."
+}
+
 #---------------------------------------------------------[Initialisations]--------------------------------------------------------
 
 #Set Error Action to Silently Continue

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # psm_LenovoBIOSUpdater
 This module uses the Lenovo BIOS Utility (WinAIA) to read and where required update the user-settable BIOS fields such as Asset ID, this data is pulled from SNIPE-IT or can simply be set using defaults
 
+## Requirements
+
+This module must be run on Windows. WinAIA and the BIOS tools it relies on are not available on non-Windows platforms. The script will stop with an error if executed elsewhere.
+
 In Addition to the licence conditions spelled out in the attached licence, the Victorian Department of Education is prohibited from utilising this resource until they treat their technicians like people and not second-class people and are prohibited from using it in any way to support SCL or SID initiatives, permanently for the former, and until there is full public disclosure including the PIA to all staff with no reservations or NDA's on the later, this is not to say that individual schools cannot use the resource, they are most welcome to, DET themselves, however, cannot.


### PR DESCRIPTION
## Summary
- ensure BIOSData script only runs on Windows, throwing an informative error otherwise
- document Windows requirement in README

## Testing
- `pwsh -NoLogo -File BIOSData.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ba57002f1c832f9c67c80f9519f8e4