### PR TITLE
Enable ShouldProcess and verbose logging

### DIFF
--- a/BIOSData.ps1
+++ b/BIOSData.ps1
@@ -1,4 +1,8 @@
 #requires -version 2
+
+[CmdletBinding()]
+param()
+
 <#
 .SYNOPSIS
   Reads Snipe-IT for machine data, then uses this data to build an array of information to set the BIOS fields on a Lenovo Device compatible with WinAIA
@@ -91,18 +95,15 @@ $dryRun = $false
 
 function Write-Log ($logMessage)
 {
-    Write-Host "$(Get-Date -UFormat '+%Y-%m-%d %H:%M:%S') - $logMessage"
-    #Write to logfile if the logpath is set
+    Write-Verbose "$(Get-Date -UFormat '+%Y-%m-%d %H:%M:%S') - $logMessage"
     if (-not [string]::IsNullOrWhiteSpace($logPath))
     {
         Add-content "$logPath\$(Get-Date -UFormat '+%Y-%m-%d %H:%M:%S') - BIOSData.log" "$(Get-Date -UFormat '+%Y-%m-%d %H:%M:%S') - $logMessage"
     }
 }
-function Write-LogBreak ($logMessage)
+function Write-LogBreak
 {
-    Write-Host "--------------------------------------------------------------------------------------"
-    
-    #Write to logfile if the logpath is set
+    Write-Debug "--------------------------------------------------------------------------------------"
     if (-not [string]::IsNullOrWhiteSpace($logPath))
     {
         Add-content "$logPath\$(Get-Date -UFormat '+%Y-%m-%d %H:%M:%S') - BIOSData.log" "--------------------------------------------------------------------------------------"
@@ -112,8 +113,14 @@ function Write-LogBreak ($logMessage)
 
 function Set-ImageData
 {
-    $biosDetails.'PRELOADPROFILE.IMAGE' = $TSEnv:TASKSEQUENCEID
-    $biosDetails.'PRELOADPROFILE.IMAGEDATE' = "$(Get-Date -format "yyyyMMdd")"
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param()
+
+    if ($PSCmdlet.ShouldProcess("BIOS details", "Update image data"))
+    {
+        $biosDetails.'PRELOADPROFILE.IMAGE' = $TSEnv:TASKSEQUENCEID
+        $biosDetails.'PRELOADPROFILE.IMAGEDATE' = "$(Get-Date -format "yyyyMMdd")"
+    }
 }
 
 function Set-Inventoried
@@ -123,74 +130,80 @@ function Set-Inventoried
 
 function Get-SnipeData
 {
-    Write-LogBreak
-    Write-Log "Retrieving device details from Snipe-IT"
-    
-    $script:snipeResult = $null #Blank Snipe result
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param()
 
-    $checkURL=$snipeURL.Substring((Select-String 'http[s]:\/\/' -Input $snipeURL).Matches[0].Length)
-
-    if ($checkURL.IndexOf('/') -eq -1)
+    if ($PSCmdlet.ShouldProcess("Snipe-IT", "Retrieve device details"))
     {
-        #Test ICMP connection
-        if ((Test-Connection -TargetName $checkURL))
+        Write-LogBreak
+        Write-Log "Retrieving device details from Snipe-IT"
+
+        $script:snipeResult = $null #Blank Snipe result
+
+        $checkURL=$snipeURL.Substring((Select-String 'http[s]:\/\/' -Input $snipeURL).Matches[0].Length)
+
+        if ($checkURL.IndexOf('/') -eq -1)
         {
-            Write-Log "Successfully to Snipe-IT server at address $checkURL"
+            #Test ICMP connection
+            if ((Test-Connection -TargetName $checkURL))
+            {
+                Write-Log "Successfully to Snipe-IT server at address $checkURL"
+            }
+            else
+            {
+                Write-Log "Cannot connect to Snipe-IT server at address $checkURL exiting"
+                exit
+            }
         }
-        else 
+
+        #Create Snipe Headers
+        $snipeHeaders=@{}
+        $snipeHeaders.Add("accept", "application/json")
+        $snipeHeaders.Add("Authorization", "Bearer $snipeAPIKey")
+
+        try
         {
-            Write-Log "Cannot connect to Snipe-IT server at address $checkURL exiting"
+            $script:snipeResult = Invoke-WebRequest -Uri "$snipeURL/api/v1/hardware/byserial/$deviceSerial" -Method GET -Headers $snipeHeaders
+
+            if ($script:snipeResult.StatusCode -eq 200)
+            {
+                #Covert from result to JSON content
+                $script:snipeResult = ConvertFrom-JSON($script:snipeResult.Content)
+
+                if ($script:snipeResult.total -eq 1)
+                {
+                    Write-Log "Sucessfully retrieved device information for $deviceSerial from Snipe-IT"
+                    $script:snipeResult = $script:snipeResult.rows[0]
+                    $biosDetails.'USERASSETDATA.ASSET_NUMBER' = $script:snipeResult.asset_tag
+                    $biosDetails.'USERASSETDATA.PURCHASE_DATE' = "$(Get-Date (($script:snipeResult.Purchase_Date).date) -format "yyyyMMdd")"
+                    $biosDetails.'USERASSETDATA.WARRANTY_END' = "$(Get-Date (($script:snipeResult.Warranty_Expires).date) -format "yyyyMMdd")"
+                    $biosDetails.'USERASSETDATA.AMOUNT' = "`$$($script:snipeResult.purchase_cost)"
+                    $biosDetails.'USERASSETDATA.WARRANTY_DURATION' = ($script:snipeResult.Warranty_Months).Split(' ')[0]
+                    $biosDetails.'NETWORKCONNECTION.SYSTEMNAME' = $script:snipeResult.name
+                }
+                elseif ($script:snipeResult.total -eq 0)
+                {
+                    Write-Log "Device $deviceSerial does not exist in Snipe-IT, Exiting"
+                    Exit
+                }
+                else
+                {
+                    Write-Log "More than one device with $deviceSerial exists in Snipe-IT, Exiting"
+                    Exit
+                }
+
+            }
+            else
+            {
+                Write-Log "Cannot retrieve device $deviceSerial from Snipe-IT due to unknown error, exiting"
+                exit
+            }
+        }
+        catch
+        {
+            Write-Log $_.Exception
             exit
         }
-    }
-
-    #Create Snipe Headers
-    $snipeHeaders=@{}
-    $snipeHeaders.Add("accept", "application/json")
-    $snipeHeaders.Add("Authorization", "Bearer $snipeAPIKey")
-
-    try 
-    {
-        $script:snipeResult = Invoke-WebRequest -Uri "$snipeURL/api/v1/hardware/byserial/$deviceSerial" -Method GET -Headers $snipeHeaders
-
-        if ($script:snipeResult.StatusCode -eq 200)
-        {
-            #Covert from result to JSON content
-            $script:snipeResult = ConvertFrom-JSON($script:snipeResult.Content)
-
-            if ($script:snipeResult.total -eq 1)
-            {
-                Write-Log "Sucessfully retrieved device information for $deviceSerial from Snipe-IT"
-                $script:snipeResult = $script:snipeResult.rows[0]
-                $biosDetails.'USERASSETDATA.ASSET_NUMBER' = $script:snipeResult.asset_tag
-                $biosDetails.'USERASSETDATA.PURCHASE_DATE' = "$(Get-Date (($script:snipeResult.Purchase_Date).date) -format "yyyyMMdd")"
-                $biosDetails.'USERASSETDATA.WARRANTY_END' = "$(Get-Date (($script:snipeResult.Warranty_Expires).date) -format "yyyyMMdd")"
-                $biosDetails.'USERASSETDATA.AMOUNT' = "`$$($script:snipeResult.purchase_cost)"
-                $biosDetails.'USERASSETDATA.WARRANTY_DURATION' = ($script:snipeResult.Warranty_Months).Split(' ')[0]
-                $biosDetails.'NETWORKCONNECTION.SYSTEMNAME' = $script:snipeResult.name
-            }
-            elseif ($script:snipeResult.total -eq 0)
-            {
-                Write-Log "Device $deviceSerial does not exist in Snipe-IT, Exiting"
-                Exit
-            }
-            else 
-            {
-                Write-Log "More than one device with $deviceSerial exists in Snipe-IT, Exiting"
-                Exit
-            }
-            
-        }
-        else 
-        {
-            Write-Log "Cannot retrieve device $deviceSerial from Snipe-IT due to unknown error, exiting"
-            exit
-        }
-    }
-    catch 
-    {
-        Write-Log $_.Exception
-        exit
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -2,3 +2,17 @@
 This module uses the Lenovo BIOS Utility (WinAIA) to read and where required update the user-settable BIOS fields such as Asset ID, this data is pulled from SNIPE-IT or can simply be set using defaults
 
 In Addition to the licence conditions spelled out in the attached licence, the Victorian Department of Education is prohibited from utilising this resource until they treat their technicians like people and not second-class people and are prohibited from using it in any way to support SCL or SID initiatives, permanently for the former, and until there is full public disclosure including the PIA to all staff with no reservations or NDA's on the later, this is not to say that individual schools cannot use the resource, they are most welcome to, DET themselves, however, cannot.
+
+## Verbose and Debug Output
+
+Use common PowerShell parameters to view additional logging:
+
+```powershell
+./BIOSData.ps1 -Verbose
+```
+
+For more detailed debugging information:
+
+```powershell
+./BIOSData.ps1 -Debug
+```


### PR DESCRIPTION
## Summary
- support common parameters by enabling `CmdletBinding` in BIOSData script
- use `Write-Verbose`/`Write-Debug` and add `SupportsShouldProcess` to key functions
- document `-Verbose` and `-Debug` usage

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68ba56f5b894832f94c03ab7d2610ea7