### PR TITLE
Use secure Snipe API key retrieval

### DIFF
--- a/Config.Sample.ps1
+++ b/Config.Sample.ps1
@@ -1,5 +1,6 @@
 #Snipe Data
-$snipeAPIKey = "my.snipe.APIKey"
+Import-Module "$PSScriptRoot\SnipeCredential.psm1" -ErrorAction Stop
+$snipeAPIKey = Get-SnipeApiKey
 $snipeURL = "https://my.snipe.url" #No trailing /
 
 #WinAIACache

--- a/README.md
+++ b/README.md
@@ -2,3 +2,14 @@
 This module uses the Lenovo BIOS Utility (WinAIA) to read and where required update the user-settable BIOS fields such as Asset ID, this data is pulled from SNIPE-IT or can simply be set using defaults
 
 In Addition to the licence conditions spelled out in the attached licence, the Victorian Department of Education is prohibited from utilising this resource until they treat their technicians like people and not second-class people and are prohibited from using it in any way to support SCL or SID initiatives, permanently for the former, and until there is full public disclosure including the PIA to all staff with no reservations or NDA's on the later, this is not to say that individual schools cannot use the resource, they are most welcome to, DET themselves, however, cannot.
+
+## Credential setup
+
+To avoid storing the Snipe-IT API key in plain text, use the helper module to save and retrieve it:
+
+```powershell
+Import-Module .\SnipeCredential.psm1
+Save-SnipeApiKey    # prompts for the API key and stores it encrypted
+```
+
+The key is saved by default to `%APPDATA%\LenovoBIOSUpdater\snipeApiKey.xml` and is tied to the current user account. Configuration scripts can retrieve the key at runtime with `Get-SnipeApiKey`.

--- a/SnipeCredential.psm1
+++ b/SnipeCredential.psm1
@@ -1,0 +1,25 @@
+function Save-SnipeApiKey {
+    [CmdletBinding()]
+    param(
+        [string]$Path = "$env:APPDATA\LenovoBIOSUpdater\snipeApiKey.xml"
+    )
+    $credential = Get-Credential -Message 'Enter Snipe API key as the password.' -UserName 'SnipeAPI'
+    $directory = Split-Path $Path
+    if (-not (Test-Path $directory)) {
+        New-Item -ItemType Directory -Path $directory | Out-Null
+    }
+    $credential | Export-Clixml -Path $Path
+}
+
+function Get-SnipeApiKey {
+    [CmdletBinding()]
+    param(
+        [string]$Path = "$env:APPDATA\LenovoBIOSUpdater\snipeApiKey.xml"
+    )
+    if (Test-Path $Path) {
+        (Import-Clixml -Path $Path).GetNetworkCredential().Password
+    }
+    else {
+        throw "Snipe API key credential not found. Run Save-SnipeApiKey to create it."
+    }
+}


### PR DESCRIPTION
## Summary
- load Snipe API key from encrypted credential instead of plain text
- add helper functions to save and read the encrypted credential
- document credential setup process

## Testing
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*
- `powershell -NoLogo -NoProfile -Command "Write-Output 'test'"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba56c8a968832f89bbc1b38826ff88