### PR TITLE
feat: add configurable log path

### DIFF
--- a/BIOSData.ps1
+++ b/BIOSData.ps1
@@ -27,6 +27,9 @@
 .EXAMPLE
   
 #>
+param(
+    [string]$LogPath
+)
 
 #---------------------------------------------------------[Initialisations]--------------------------------------------------------
 
@@ -37,7 +40,6 @@ $ErrorActionPreference = "SilentlyContinue"
 
 #----------------------------------------------------------[Declarations]----------------------------------------------------------
 
-$logPath = "C:\Temp\"
 
 
 # These are the fields able to be set, use this array to set defaults - anything that has not value set upon processing will be ignored and thus no change will be made to existing data. To Blank the field please set to BLANK (Case Sesnsive)
@@ -345,15 +347,21 @@ function Get-CurrentBIOSData
 
 #-----------------------------------------------------------[Execution]------------------------------------------------------------
 
-#Start log if file path exists
-if (!([string]::IsNullOrWhiteSpace($logPath)) -and !(Test-Path $logPath))
-{
-    New-Item -ItemType Directory -Force -Path $logPath
-}
-
 #Modules - Imported here to override defaults
 Import-Module "$PSScriptRoot/Config.ps1" -Force #Contains protected data (API Keys, URLs etc)
 #Import-Module "$PSScriptRoot/DevEnv.ps1" -Force ##Temporary Variables used for development and troubleshooting
+
+# Determine log path; parameter overrides config, otherwise use temporary directory
+if ($PSBoundParameters.ContainsKey('LogPath')) {
+    $logPath = $LogPath
+} elseif ([string]::IsNullOrWhiteSpace($logPath)) {
+    $logPath = [System.IO.Path]::GetTempPath()
+}
+
+# Ensure log directory exists
+if (-not [string]::IsNullOrWhiteSpace($logPath) -and -not (Test-Path $logPath)) {
+    New-Item -ItemType Directory -Force -Path $logPath | Out-Null
+}
 
 # Retrieve Serial from BIOS
 $deviceSerial = (Get-CimInstance win32_bios | Select-Object serialnumber).serialnumber

--- a/Config.Sample.ps1
+++ b/Config.Sample.ps1
@@ -4,3 +4,7 @@ $snipeURL = "https://my.snipe.url" #No trailing /
 
 #WinAIACache
 $winAIACache = "" #No trailing \ - null or blank will not instigate this check, please use UNC variable for network paths
+
+#Log output (optional)
+$logPath = "C:\Temp" #Override with -LogPath parameter when running BIOSData.ps1
+

--- a/README.md
+++ b/README.md
@@ -2,3 +2,14 @@
 This module uses the Lenovo BIOS Utility (WinAIA) to read and where required update the user-settable BIOS fields such as Asset ID, this data is pulled from SNIPE-IT or can simply be set using defaults
 
 In Addition to the licence conditions spelled out in the attached licence, the Victorian Department of Education is prohibited from utilising this resource until they treat their technicians like people and not second-class people and are prohibited from using it in any way to support SCL or SID initiatives, permanently for the former, and until there is full public disclosure including the PIA to all staff with no reservations or NDA's on the later, this is not to say that individual schools cannot use the resource, they are most welcome to, DET themselves, however, cannot.
+
+## Logging
+
+`BIOSData.ps1` accepts an optional `-LogPath` parameter to control where log files are written. If not supplied, logs are saved to the system temporary directory.
+
+```powershell
+./BIOSData.ps1 -LogPath "C:\Temp"
+```
+
+The same path can be set in `Config.ps1` by defining `$logPath`.
+


### PR DESCRIPTION
## Summary
- allow BIOSData.ps1 to accept optional `-LogPath` parameter
- default logs to a safe temporary location and create directory if needed
- document log path configuration in README and sample config

## Testing
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68ba56d7ff64832faa69205a210332cc