### PR TITLE
Add dry-run support to BIOS updater

### DIFF
--- a/BIOSData.ps1
+++ b/BIOSData.ps1
@@ -8,8 +8,8 @@
 
 .DESCRIPTION
 
-.PARAMETER <Parameter_Name>
-  <Brief description of parameter input required. Repeat this attribute if required>
+.PARAMETER dryRun
+  When specified, operations that would modify BIOS data are logged but not executed.
 
 .INPUTS
     Serial number of device (pulled from BIOS)
@@ -27,6 +27,10 @@
 .EXAMPLE
   
 #>
+
+param(
+    [switch]$dryRun
+)
 
 #---------------------------------------------------------[Initialisations]--------------------------------------------------------
 
@@ -82,9 +86,6 @@ $winAIAInternet = "https://download.lenovo.com/pccbbs/mobiles"
 
 #Script Variables - Declared to stop it being generated multiple times per run
 $script:snipeResult = $null #Blank Snipe result
-
-#DryRun Settings
-$dryRun = $false
 
 #-----------------------------------------------------------[Functions]------------------------------------------------------------
 
@@ -243,7 +244,7 @@ function New-CustomField
 function Set-BIOSData
 {
     Write-LogBreak
-    if ($dryRun -eq $false)
+    if (-not $dryRun)
     {
         Write-Log "Setting BIOS Data - Commiting to BIOS"
     }
@@ -259,22 +260,29 @@ function Set-BIOSData
         if (-not [string]::IsNullOrWhiteSpace($field.Value) -and ($biosCurrent.Keys -notcontains $field.Key -or ($biosCurrent.Keys -contains $field.Key -and ($biosCurrent.($field.Key)) -ne $field.Value)))
         {
             $noRows = $false
-            if ($dryRun -eq $false)
-            {
-                if ($field.Value -ne "BLANK")
-                {
-                    Write-Log "Setting $($field.Key) to $($field.Value)"
-                    .\WinAIA64.exe -silent -set "`"$($field.Key)=$($field.Value)`""
-                }
-                elseif ($field.Value -eq "BLANK" -and $biosCurrent.Keys -contains $field.Key)
-                {
-                    Write-Log "Setting $($field.Key) to $($field.Value)"
-                    .\WinAIA64.exe -silent -set "`"$($field.Key)=`""
-                }
-            }
-            else
+            if ($field.Value -ne "BLANK")
             {
                 Write-Log "Setting $($field.Key) to $($field.Value)"
+                if (-not $dryRun)
+                {
+                    .\WinAIA64.exe -silent -set "`"$($field.Key)=$($field.Value)`""
+                }
+                else
+                {
+                    Write-Log 'Dry run: skipping write'
+                }
+            }
+            elseif ($field.Value -eq "BLANK" -and $biosCurrent.Keys -contains $field.Key)
+            {
+                Write-Log "Setting $($field.Key) to $($field.Value)"
+                if (-not $dryRun)
+                {
+                    .\WinAIA64.exe -silent -set "`"$($field.Key)=`""
+                }
+                else
+                {
+                    Write-Log 'Dry run: skipping write'
+                }
             }
 
         }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
 # psm_LenovoBIOSUpdater
 This module uses the Lenovo BIOS Utility (WinAIA) to read and where required update the user-settable BIOS fields such as Asset ID, this data is pulled from SNIPE-IT or can simply be set using defaults
 
+## Dry run
+
+Use the `-dryRun` switch to simulate BIOS updates without committing any changes.
+
+```powershell
+# Preview operations without writing to BIOS
+./BIOSData.ps1 -dryRun
+
+# Equivalent explicit invocation
+./BIOSData.ps1 -dryRun:$true
+```
+
 In Addition to the licence conditions spelled out in the attached licence, the Victorian Department of Education is prohibited from utilising this resource until they treat their technicians like people and not second-class people and are prohibited from using it in any way to support SCL or SID initiatives, permanently for the former, and until there is full public disclosure including the PIA to all staff with no reservations or NDA's on the later, this is not to say that individual schools cannot use the resource, they are most welcome to, DET themselves, however, cannot.


### PR DESCRIPTION
## Summary
- expose `-dryRun` switch in main BIOS updater script
- skip BIOS writes when dry-run is enabled
- document dry-run usage with examples

## Testing
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68ba56bf9668832fbd6bb13d79ac8e02