### PR TITLE
Add Pester tests and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,10 @@
 This module uses the Lenovo BIOS Utility (WinAIA) to read and where required update the user-settable BIOS fields such as Asset ID, this data is pulled from SNIPE-IT or can simply be set using defaults
 
 In Addition to the licence conditions spelled out in the attached licence, the Victorian Department of Education is prohibited from utilising this resource until they treat their technicians like people and not second-class people and are prohibited from using it in any way to support SCL or SID initiatives, permanently for the former, and until there is full public disclosure including the PIA to all staff with no reservations or NDA's on the later, this is not to say that individual schools cannot use the resource, they are most welcome to, DET themselves, however, cannot.
+## Running Tests
+
+This project uses [Pester](https://pester.dev/) for unit testing. After installing PowerShell and the Pester module, run the test suite from the repository root:
+
+```powershell
+pwsh -NoLogo -Command Invoke-Pester
+```

--- a/Tests/BIOSData.Tests.ps1
+++ b/Tests/BIOSData.Tests.ps1
@@ -1,0 +1,69 @@
+BeforeAll {
+    $scriptPath = Join-Path $PSScriptRoot '..' 'BIOSData.ps1'
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($scriptPath, [ref]$null, [ref]$null)
+    $funcAsts = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)
+    foreach ($funcAst in $funcAsts) {
+        # Replace exit with throw so tests can capture failures without terminating PowerShell
+        $funcText = $funcAst.Extent.Text -replace '\bexit\b', 'throw'
+        Invoke-Expression $funcText
+    }
+}
+
+describe 'Set-ImageData' {
+    BeforeEach {
+        Set-Variable -Name biosDetails -Value @{ 'PRELOADPROFILE.IMAGE'=''; 'PRELOADPROFILE.IMAGEDATE'='' } -Scope Global
+        if (Get-PSDrive -Name TSEnv -ErrorAction SilentlyContinue) { Remove-PSDrive -Name TSEnv -Force }
+        New-PSDrive -Name TSEnv -PSProvider Variable -Root '' | Out-Null
+        Set-Item TSEnv:TASKSEQUENCEID 'TS123'
+    }
+    it 'sets image and date based on task sequence' {
+        Set-ImageData
+        $global:biosDetails.'PRELOADPROFILE.IMAGE' | Should -Be 'TS123'
+        $global:biosDetails.'PRELOADPROFILE.IMAGEDATE' | Should -Match '^\d{8}$'
+    }
+}
+
+describe 'Get-SnipeData' {
+    BeforeEach {
+        Set-Variable -Name biosDetails -Value @{} -Scope Global
+        Set-Variable -Name snipeResult -Value $null -Scope Global
+        Set-Variable -Name snipeURL -Value 'https://snipe.example.com' -Scope Global
+        Set-Variable -Name snipeAPIKey -Value 'token' -Scope Global
+        Set-Variable -Name deviceSerial -Value 'ABC123' -Scope Global
+        Set-Variable -Name logPath -Value '' -Scope Global
+        Mock Write-Log {}
+    }
+    it 'populates bios details when request succeeds' {
+        Mock Test-Connection { $true }
+        $response = [pscustomobject]@{ StatusCode = 200; Content = '{"total":1,"rows":[{"asset_tag":"TAG1","Purchase_Date":{"date":"2020-01-01"},"Warranty_Expires":{"date":"2025-01-01"},"purchase_cost":1000,"Warranty_Months":"12 months","name":"Device1"}]}' }
+        Mock Invoke-WebRequest { $response }
+        Get-SnipeData
+        $global:biosDetails.'USERASSETDATA.ASSET_NUMBER' | Should -Be 'TAG1'
+        $global:biosDetails.'NETWORKCONNECTION.SYSTEMNAME' | Should -Be 'Device1'
+    }
+    it 'throws when Snipe server cannot be reached' {
+        Mock Test-Connection { $false }
+        { Get-SnipeData } | Should -Throw
+    }
+}
+
+describe 'Set-BIOSData' {
+     BeforeEach {
+         Push-Location $TestDrive
+         Set-Variable -Name dryRun -Value $true -Scope Global
+         Set-Variable -Name logPath -Value '' -Scope Global
+         Set-Variable -Name biosDetails -Value @{ 'USERASSETDATA.ASSET_NUMBER' = 'TAG1' } -Scope Global
+         Set-Variable -Name biosCurrent -Value @{} -Scope Global
+         Set-Content -Path 'WinAIA64.exe' -Value "#!/bin/sh`necho called > run.log" -NoNewline
+         chmod +x 'WinAIA64.exe'
+         Mock Write-Log {}
+     }
+     it 'does not call WinAIA64.exe when dry run is enabled' {
+         Set-BIOSData
+         Test-Path 'run.log' | Should -BeFalse
+         Assert-MockCalled Write-Log -ParameterFilter { $logMessage -eq 'Setting BIOS Data - Dry Run' } -Times 1
+     }
+     AfterEach {
+         Pop-Location
+     }
+ }


### PR DESCRIPTION
## Summary
- add Pester unit tests for image info, Snipe-IT lookups, and dry-run BIOS writes
- document running the test suite in the README

## Testing
- `pwsh -NoLogo -Command Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_e_68ba56c20144832f963bd3ae272836cc