### PR TITLE
Add linting and testing scripts with CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install PowerShell modules
+        shell: pwsh
+        run: |
+          Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
+          Install-Module -Name Pester -Force -Scope CurrentUser
+      - name: Run lint
+        shell: pwsh
+        run: ./lint.ps1
+      - name: Run tests
+        shell: pwsh
+        run: ./test.ps1

--- a/Tests/Basic.Tests.ps1
+++ b/Tests/Basic.Tests.ps1
@@ -1,0 +1,5 @@
+Describe "Repository tests" {
+    It "contains BIOSData script" {
+        Test-Path "$PSScriptRoot/../BIOSData.ps1" | Should -BeTrue
+    }
+}

--- a/lint.ps1
+++ b/lint.ps1
@@ -1,0 +1,2 @@
+Write-Host "Running PSScriptAnalyzer..."
+Invoke-ScriptAnalyzer -Path . -Recurse

--- a/test.ps1
+++ b/test.ps1
@@ -1,0 +1,2 @@
+Write-Host "Running Pester tests..."
+Invoke-Pester -Path Tests


### PR DESCRIPTION
## Summary
- add PSScriptAnalyzer lint script
- add Pester tests with basic repository check
- run lint and tests in GitHub Actions

## Testing
- `pwsh -File lint.ps1` *(fails: command not found)*
- `pwsh -File test.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba57309058832f99facc93c1ddf6d1