### PR TITLE
Document BIOS updater functions with comment-based help

### DIFF
--- a/BIOSData.ps1
+++ b/BIOSData.ps1
@@ -89,8 +89,20 @@ $dryRun = $false
 #-----------------------------------------------------------[Functions]------------------------------------------------------------
 
 
-function Write-Log ($logMessage)
-{
+function Write-Log {
+    <#
+    .SYNOPSIS
+    Writes a timestamped message to the console and optional log file.
+
+    .PARAMETER logMessage
+    Text to record.
+
+    .EXAMPLE
+    Write-Log -logMessage "Starting update"
+    #>
+    param (
+        $logMessage
+    )
     Write-Host "$(Get-Date -UFormat '+%Y-%m-%d %H:%M:%S') - $logMessage"
     #Write to logfile if the logpath is set
     if (-not [string]::IsNullOrWhiteSpace($logPath))
@@ -98,10 +110,22 @@ function Write-Log ($logMessage)
         Add-content "$logPath\$(Get-Date -UFormat '+%Y-%m-%d %H:%M:%S') - BIOSData.log" "$(Get-Date -UFormat '+%Y-%m-%d %H:%M:%S') - $logMessage"
     }
 }
-function Write-LogBreak ($logMessage)
-{
+function Write-LogBreak {
+    <#
+    .SYNOPSIS
+    Writes a separator line to the console and log file.
+
+    .PARAMETER logMessage
+    Optional message to accompany the break.
+
+    .EXAMPLE
+    Write-LogBreak -logMessage "Starting section"
+    #>
+    param (
+        $logMessage
+    )
     Write-Host "--------------------------------------------------------------------------------------"
-    
+
     #Write to logfile if the logpath is set
     if (-not [string]::IsNullOrWhiteSpace($logPath))
     {
@@ -112,20 +136,50 @@ function Write-LogBreak ($logMessage)
 
 function Set-ImageData
 {
+    <#
+    .SYNOPSIS
+    Sets image-related BIOS fields from task sequence data.
+
+    .PARAMETER None
+    This function has no parameters.
+
+    .EXAMPLE
+    Set-ImageData
+    #>
     $biosDetails.'PRELOADPROFILE.IMAGE' = $TSEnv:TASKSEQUENCEID
     $biosDetails.'PRELOADPROFILE.IMAGEDATE' = "$(Get-Date -format "yyyyMMdd")"
 }
 
 function Set-Inventoried
 {
+    <#
+    .SYNOPSIS
+    Updates BIOS fields to mark the device as inventoried.
+
+    .PARAMETER None
+    This function has no parameters.
+
+    .EXAMPLE
+    Set-Inventoried
+    #>
     $biosDetails.'USERASSETDATA.LAST_INVENTORIED' = "$(Get-Date -format "yyyyMMdd")"
 }
 
 function Get-SnipeData
 {
+    <#
+    .SYNOPSIS
+    Retrieves asset information from Snipe-IT and populates BIOS fields.
+
+    .PARAMETER None
+    This function has no parameters.
+
+    .EXAMPLE
+    Get-SnipeData
+    #>
     Write-LogBreak
     Write-Log "Retrieving device details from Snipe-IT"
-    
+
     $script:snipeResult = $null #Blank Snipe result
 
     $checkURL=$snipeURL.Substring((Select-String 'http[s]:\/\/' -Input $snipeURL).Matches[0].Length)
@@ -196,6 +250,19 @@ function Get-SnipeData
 
 function New-CustomField
 {
+    <#
+    .SYNOPSIS
+    Adds or updates a custom BIOS field.
+
+    .PARAMETER fieldKey
+    Key name appended to the USERDEVICE domain.
+
+    .PARAMETER fieldValue
+    Value to assign to the field.
+
+    .EXAMPLE
+    New-CustomField -fieldKey "ITAM_NUMBER" -fieldValue "12345"
+    #>
     Param(
         [string]$fieldKey, #Appended to the USERDEVICE domain
         [string]$fieldValue #Value the field should contain
@@ -242,12 +309,22 @@ function New-CustomField
 
 function Set-BIOSData
 {
+    <#
+    .SYNOPSIS
+    Commits any pending BIOS field changes using WinAIA.
+
+    .PARAMETER None
+    This function has no parameters.
+
+    .EXAMPLE
+    Set-BIOSData
+    #>
     Write-LogBreak
     if ($dryRun -eq $false)
     {
         Write-Log "Setting BIOS Data - Commiting to BIOS"
     }
-    else 
+    else
     {
         Write-Log "Setting BIOS Data - Dry Run"
     }
@@ -290,6 +367,16 @@ function Set-BIOSData
 #Current data is written to log as it is read, custom values are counted so that we do not try to set more than the allowed custom values (5)
 function Get-CurrentBIOSData
 {
+    <#
+    .SYNOPSIS
+    Reads current BIOS settings into a hashtable for comparison.
+
+    .PARAMETER None
+    This function has no parameters.
+
+    .EXAMPLE
+    Get-CurrentBIOSData
+    #>
     Write-LogBreak
     Write-Log "Retrieving current BIOS data"
     Write-LogBreak

--- a/README.md
+++ b/README.md
@@ -2,3 +2,11 @@
 This module uses the Lenovo BIOS Utility (WinAIA) to read and where required update the user-settable BIOS fields such as Asset ID, this data is pulled from SNIPE-IT or can simply be set using defaults
 
 In Addition to the licence conditions spelled out in the attached licence, the Victorian Department of Education is prohibited from utilising this resource until they treat their technicians like people and not second-class people and are prohibited from using it in any way to support SCL or SID initiatives, permanently for the former, and until there is full public disclosure including the PIA to all staff with no reservations or NDA's on the later, this is not to say that individual schools cannot use the resource, they are most welcome to, DET themselves, however, cannot.
+
+## Documentation
+
+All public functions include comment-based help. After loading the script, run PowerShell's `Get-Help` for usage information, for example:
+
+```powershell
+Get-Help Write-Log -Full
+```


### PR DESCRIPTION
## Summary
- add comment-based help with Synopsis, Parameter, and Example sections for all public functions
- document availability of help in README

## Testing
- `/tmp/pwsh/pwsh -NoLogo -Command ". ./functions.ps1; Get-Help Write-Log; Get-Help Write-LogBreak; Get-Help Set-ImageData; Get-Help Set-Inventoried; Get-Help Get-SnipeData; Get-Help New-CustomField; Get-Help Set-BIOSData; Get-Help Get-CurrentBIOSData"`


------
https://chatgpt.com/codex/tasks/task_e_68ba56b1bf8c832faf7c55ce7b9d5f31