### PR TITLE
Add GitHub Actions workflow for PowerShell linting and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine PowerShell module path
+        id: psmodulepath
+        shell: pwsh
+        run: |
+          $modulePath = ($env:PSModulePath -split [IO.Path]::PathSeparator | Where-Object { $_ -like "$HOME*" })[0]
+          "dir=$modulePath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8
+
+      - name: Cache PowerShell modules
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.psmodulepath.outputs.dir }}
+          key: ${{ runner.os }}-psmodules-${{ hashFiles('.github/workflows/ci.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-psmodules-
+
+      - name: Install modules
+        shell: pwsh
+        run: |
+          Set-PSRepository PSGallery -InstallationPolicy Trusted
+          Install-Module PSScriptAnalyzer -Scope CurrentUser -Force
+          Install-Module Pester -Scope CurrentUser -Force
+
+      - name: Run PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Import-Module PSScriptAnalyzer
+          $results = Invoke-ScriptAnalyzer -Path . -Recurse
+          if ($results) {
+            foreach ($r in $results) {
+              $level = if ($r.Severity -eq 'Error') { 'error' } else { 'warning' }
+              Write-Output "::${level} file=$($r.ScriptName),line=$($r.Line),col=$($r.Column)::[$($r.RuleName)] $($r.Message)"
+            }
+            exit 1
+          }
+
+      - name: Run Pester
+        shell: pwsh
+        run: |
+          $tests = Get-ChildItem -Path . -Recurse -Filter '*.Tests.ps1'
+          if ($tests) {
+            Invoke-Pester -CI -Output Detailed
+          } else {
+            Write-Host 'No tests found.'
+          }


### PR DESCRIPTION
## Summary
- run PSScriptAnalyzer and Pester on pushes and pull requests
- cache PowerShell modules to speed up workflow runs
- surface lint and test results in PR checks

## Testing
- `pwsh -NoLogo -NoProfile -Command 'Import-Module PSScriptAnalyzer; Invoke-ScriptAnalyzer -Path . -Recurse'`
- `pwsh -NoLogo -NoProfile -Command 'Invoke-Pester'` *(fails: No test files were found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba56b55cac832f8446a28c923897da